### PR TITLE
CI: Have nc-autotools use source distribution

### DIFF
--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -195,6 +195,19 @@ jobs:
         run: CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
+      - name: Create source distribution
+        shell: bash -l {0}
+        if: ${{ success() }}
+        run: make dist -j
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: netcdf-c-autotools-source-distribution
+          path: |
+            *.tar*
+            *.zip
+            *.tgz
+
   ##
   # Parallel
   ##
@@ -448,7 +461,19 @@ jobs:
         use_nczarr: [ nczarr_off, nczarr_on ]
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/download_artifact@v3
+        with:
+          name: netcdf-c-autotools-source-distribution
+
+      - name: Unpack source distribution
+        shell: bash -l {0}
+        run: |
+          if [ -f *.zip ];
+          then
+            unzip *.zip
+          else
+            tar xvzf $(ls *.tar* *.tgz *.zip | head -1)
+          fi
 
       - name: Install System dependencies
         shell: bash -l {0}

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -474,6 +474,7 @@ jobs:
           else
             tar xvzf $(ls *.tar* *.tgz *.zip | head -1)
           fi
+          cd netcdf-c*
 
       - name: Install System dependencies
         shell: bash -l {0}
@@ -522,11 +523,20 @@ jobs:
 
       - name: Run autoconf
         shell: bash -l {0}
-        run: autoreconf -if
+        run: |
+          if [ -d netcdf-c* ];
+          then
+              cd netcdf-c*
+          fi
+          autoreconf -if
 
       - name: Configure
         shell: bash -l {0}
         run: |
+          if [ -d netcdf-c* ];
+          then
+              cd netcdf-c*
+          fi
           current_directory="$(pwd)"
           mkdir ../build
           cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} "${current_directory}/configure" ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}
@@ -534,29 +544,56 @@ jobs:
 
       - name: Look at config.log if error
         shell: bash -l {0}
-        run: cd ../build && cat config.log
+        run: |
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && cat config.log
         if: ${{ failure() }}
 
       - name: Print Summary
         shell: bash -l {0}
-        run: cd ../build && cat libnetcdf.settings
+        run: |
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && cat libnetcdf.settings
 
       - name: Build Library and Utilities
         shell: bash -l {0}
         run: |
-          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j
         if: ${{ success() }}
 
       - name: Build Tests
         shell: bash -l {0}
         run: |
-          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check TESTS="" -j
         if: ${{ success() }}
 
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
+          if [ -d ../build ];
+          then
+              cd ../build
+          else
+              cd build
+          fi && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make check -j
         if: ${{ success() }}
 
   nc-cmake:

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -461,7 +461,7 @@ jobs:
         use_nczarr: [ nczarr_off, nczarr_on ]
     steps:
 
-      - uses: actions/download_artifact@v3
+      - uses: actions/download-artifact@v3
         with:
           name: netcdf-c-autotools-source-distribution
 

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -480,6 +480,7 @@ jobs:
               if [ -d ${name} ];
               then
                   cd ${name}
+                  break
               fi
           done
 
@@ -531,10 +532,14 @@ jobs:
       - name: Run autoconf
         shell: bash -l {0}
         run: |
-          if [ -d netcdf-c* ];
-          then
-              cd netcdf-c*
-          fi
+          for name in netcdf-c*;
+          do
+              if [ -d ${name} ];
+              then
+                  cd ${name}
+                  break
+              fi
+          done
           autoreconf -if
 
       - name: Configure

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -474,8 +474,14 @@ jobs:
           else
             tar xvzf $(ls *.tar* *.tgz *.zip | head -1)
           fi
-          ls netcdf-c*
-          cd netcdf-c*
+          ls -d netcdf-c*
+          for name in netcdf-c*;
+          do
+              if [ -d ${name} ];
+              then
+                  cd ${name}
+              fi
+          done
 
       - name: Install System dependencies
         shell: bash -l {0}

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -474,6 +474,7 @@ jobs:
           else
             tar xvzf $(ls *.tar* *.tgz *.zip | head -1)
           fi
+          ls netcdf-c*
           cd netcdf-c*
 
       - name: Install System dependencies

--- a/.github/workflows/run_tests_ubuntu.yml
+++ b/.github/workflows/run_tests_ubuntu.yml
@@ -545,10 +545,14 @@ jobs:
       - name: Configure
         shell: bash -l {0}
         run: |
-          if [ -d netcdf-c* ];
-          then
-              cd netcdf-c*
-          fi
+          for name in netcdf-c*;
+          do
+              if [ -d ${name} ];
+              then
+                  cd ${name}
+                  break
+              fi
+          done
           current_directory="$(pwd)"
           mkdir ../build
           cd ../build && CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} "${current_directory}/configure" ${ENABLE_HDF5} ${ENABLE_DAP} ${ENABLE_NCZARR}


### PR DESCRIPTION
Instead of a clone of the repository, have the nc-autotools job work from a source distribution prepared by a previous autotools CI job.

This should catch most of the "files not included in EXTRA_DIST" or similar issues I remember, and probably most of the "netcdf-c does not pass make distcheck" errors.